### PR TITLE
Fix shorthand annotation

### DIFF
--- a/e2etest/marshal_test.go
+++ b/e2etest/marshal_test.go
@@ -39,7 +39,7 @@ func TestSimpleMarshal(t *testing.T) {
 	msg.Ill.FirstFieldArray2 = "first-arr2"
 	msg.Ill.SecondfieldArray2 = "second-arr2"
 
-	lines, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
+	lines, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.StandardNotation)
 
 	for _, line := range lines {
 		linestr := string(line)
@@ -69,7 +69,7 @@ func TestGenverateSequence(t *testing.T) {
 	msg.Patient[1].LastName = "Secundus'"
 	msg.Patient[1].FirstName = "Secundie"
 
-	lines, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
+	lines, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.StandardNotation)
 
 	assert.Nil(t, err)
 	// output on screen
@@ -117,7 +117,7 @@ func TestNestedStruct(t *testing.T) {
 	msg.PatientResult[1].Result[0].MeasurementValueOfDevice = "present"
 	msg.PatientResult[1].Result[0].Units = "none"
 
-	lines, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
+	lines, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.StandardNotation)
 
 	assert.Nil(t, err)
 	// output on screen
@@ -332,7 +332,7 @@ func TestQueryMessage(t *testing.T) {
 	query.Terminator.TerminatorCode = "N"
 
 	// Test with no Querydata provided
-	filedata, err := astm.Marshal(query, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
+	filedata, err := astm.Marshal(query, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.StandardNotation)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "H|\\^&||||||||||||", string(filedata[0]))
@@ -342,7 +342,7 @@ func TestQueryMessage(t *testing.T) {
 		StartingRangeIDNumber: "SampleCode1",
 		UniversalTestID:       "ALL",
 	})
-	filedata, err = astm.Marshal(query, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
+	filedata, err = astm.Marshal(query, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.StandardNotation)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "H|\\^&||||||||||||", string(filedata[0]))
@@ -400,7 +400,6 @@ func TestMarshalMultipleOrder(t *testing.T) {
 }
 
 func TestShorthandOnStandardMessage(t *testing.T) {
-
 	msg := standardlis2a2.DefaultMessage{
 		Header: standardlis2a2.Header{
 			Delimiters:     "\\^&",
@@ -439,11 +438,11 @@ func TestShorthandOnStandardMessage(t *testing.T) {
 	}
 
 	filedata, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
-	fmt.Printf("%#v\n", filedata)
+
 	assert.Nil(t, err)
 	assert.Equal(t, 6, len(filedata))
-	assert.Equal(t, []byte("M|1|"), filedata[1])
-	assert.Equal(t, []byte("P|1|"), filedata[2])
+	assert.Equal(t, []byte("M|1"), filedata[1])
+	assert.Equal(t, []byte("P|1"), filedata[2])
 	assert.Equal(t, []byte("O|1|VAL24981209||Pool_Cell|R||||||N||||TestData"), filedata[3])
 	assert.Equal(t, []byte("O|2|VAL24981210||Pool_Cell|R||||||N||||TestData"), filedata[4])
 	assert.Equal(t, []byte("L|1|N"), filedata[5])

--- a/e2etest/marshal_test.go
+++ b/e2etest/marshal_test.go
@@ -441,4 +441,10 @@ func TestShorthandOnStandardMessage(t *testing.T) {
 	filedata, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
 	fmt.Printf("%#v\n", filedata)
 	assert.Nil(t, err)
+	assert.Equal(t, 6, len(filedata))
+	assert.Equal(t, []byte("M|1|"), filedata[1])
+	assert.Equal(t, []byte("P|1|"), filedata[2])
+	assert.Equal(t, []byte("O|1|VAL24981209||Pool_Cell|R||||||N||||TestData"), filedata[3])
+	assert.Equal(t, []byte("O|2|VAL24981210||Pool_Cell|R||||||N||||TestData"), filedata[4])
+	assert.Equal(t, []byte("L|1|N"), filedata[5])
 }

--- a/e2etest/marshal_test.go
+++ b/e2etest/marshal_test.go
@@ -398,3 +398,47 @@ func TestMarshalMultipleOrder(t *testing.T) {
 	}
 
 }
+
+func TestShorthandOnStandardMessage(t *testing.T) {
+
+	msg := standardlis2a2.DefaultMessage{
+		Header: standardlis2a2.Header{
+			Delimiters:     "\\^&",
+			SenderNameOrID: "LIS",
+			ReceiverID:     "NotExistantTestSystem",
+			DateAndTime:    time.Now(),
+		},
+		OrderResults: []standardlis2a2.PORC{
+			{
+				Patient: standardlis2a2.Patient{},
+				OrderCommentedResult: []standardlis2a2.OrderCommentedResult{
+					{
+						Order: standardlis2a2.Order{
+							SpecimenID:         "VAL24981209",
+							UniversalTestID:    "Pool_Cell",
+							Priority:           "R",
+							ActionCode:         "N",
+							SpecimenDescriptor: "TestData",
+						},
+					},
+					{
+						Order: standardlis2a2.Order{
+							SpecimenID:         "VAL24981210",
+							UniversalTestID:    "Pool_Cell",
+							Priority:           "R",
+							ActionCode:         "N",
+							SpecimenDescriptor: "TestData",
+						},
+					},
+				},
+			},
+		},
+		Terminator: standardlis2a2.Terminator{
+			TerminatorCode: "N",
+		},
+	}
+
+	filedata, err := astm.Marshal(msg, astm.EncodingASCII, astm.TimezoneEuropeBerlin, astm.ShortNotation)
+	fmt.Printf("%#v\n", filedata)
+	assert.Nil(t, err)
+}

--- a/lib/standardlis2a2/messageformat.go
+++ b/lib/standardlis2a2/messageformat.go
@@ -155,7 +155,7 @@ type Terminator struct {
 // Lis2Manufacturer -Manufacturer Record
 // https://samson-rus.com/wp-content/files/LIS2-A2.pdf
 type Manufacturer struct {
-	SequenceNumber string `astm:"2,sequence"` // 14.2 (see https://samson-rus.com/wp-content/files/LIS2-A2.pdf)
+	SequenceNumber int    `astm:"2,sequence"` // 14.2 (see https://samson-rus.com/wp-content/files/LIS2-A2.pdf)
 	F2             string `astm:"3"`          // 14.3
 	F3             string `astm:"4"`          // 14.4
 	F4             string `astm:"5"`          // 14.5


### PR DESCRIPTION
Short notation wasn't working, it always used standard notation on marshal.